### PR TITLE
Fix portability for android-wrapper.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,14 @@ The artifact is available through <a href="https://search.maven.org/search?q=g:c
 <dependency>
   <groupId>com.what3words</groupId>
   <artifactId>w3w-java-wrapper</artifactId>
-  <version>3.1.3</version>
+  <version>3.1.4</version>
 </dependency>
 ```
 
 ### Gradle
 
 ```
-implementation 'com.what3words:w3w-java-wrapper:3.1.3'
+implementation 'com.what3words:w3w-java-wrapper:3.1.4'
 ```
 
 ## Documentation

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>com.what3words</groupId>
 	<artifactId>w3w-java-wrapper</artifactId>
-	<version>3.1.3</version>
+	<version>3.1.4</version>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/main/java/com/what3words/javawrapper/request/AutosuggestRequest.java
+++ b/src/main/java/com/what3words/javawrapper/request/AutosuggestRequest.java
@@ -1,6 +1,8 @@
 package com.what3words.javawrapper.request;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Collectors;
 
 import com.what3words.javawrapper.What3WordsV3;
@@ -9,7 +11,7 @@ import com.what3words.javawrapper.response.Autosuggest;
 
 public class AutosuggestRequest extends Request<Autosuggest> {
     private String input;
-    private String nResults; 
+    private String nResults;
     private String focus;
     private String nFocusResults;
     private String clipToCountry;
@@ -22,7 +24,7 @@ public class AutosuggestRequest extends Request<Autosuggest> {
 
     private AutosuggestRequest(Builder builder) {
         super(builder.api);
-        
+
         input = builder.input;
         nResults = builder.nResults;
         focus = builder.focus;
@@ -39,10 +41,10 @@ public class AutosuggestRequest extends Request<Autosuggest> {
     private Autosuggest execute() {
         return super.execute(api.what3words().autosuggest(input, nResults, focus, nFocusResults, clipToCountry, clipToBoundingBox, clipToCircle, clipToPolygon, inputType, language, preferLand), Autosuggest.class);
     }
-    
+
     public static class Builder extends AbstractBuilder<Autosuggest> {
         private String input;
-        private String nResults; 
+        private String nResults;
         private String focus;
         private String nFocusResults;
         private String clipToCountry;
@@ -52,16 +54,16 @@ public class AutosuggestRequest extends Request<Autosuggest> {
         private String inputType;
         private String language;
         private String preferLand;
-        
+
         public Builder(What3WordsV3 api, String input) {
             super(api);
             this.input = input;
         }
-        
+
         /**
-         * Set the number of AutoSuggest results to return. A maximum of 100 results can be specified, if a number greater than this is requested, 
+         * Set the number of AutoSuggest results to return. A maximum of 100 results can be specified, if a number greater than this is requested,
          * this will be truncated to the maximum. The default is 3
-         * 
+         *
          * @param n the number of AutoSuggest results to return
          * @return a {@link Builder} instance suitable for invoking a <code>autosuggest</code> API request
          */
@@ -69,11 +71,11 @@ public class AutosuggestRequest extends Request<Autosuggest> {
             this.nResults = String.valueOf(n);
             return this;
         }
-        
+
         /**
-         * This is a location, specified as a latitude (often where the user making the query is). If specified, the results will be weighted to 
+         * This is a location, specified as a latitude (often where the user making the query is). If specified, the results will be weighted to
          * give preference to those near the <code>focus</code>. For convenience, longitude is allowed to wrap around the 180 line, so 361 is equivalent to 1.
-         * 
+         *
          * @param coordinates the focus to use
          * @return a {@link Builder} instance suitable for invoking a <code>autosuggest</code> API request
          */
@@ -81,13 +83,13 @@ public class AutosuggestRequest extends Request<Autosuggest> {
             this.focus = String.valueOf(coordinates.lat) + "," + String.valueOf(coordinates.lng);
             return this;
         }
-        
+
         /**
-         * Specifies the number of results (must be &lt;= nResults) within the results set which will have a focus. Defaults to <code>nResults</code>. 
-         * This allows you to run autosuggest with a mix of focussed and unfocussed results, to give you a "blend" of the two. This is exactly what the old V2 
-         * <code>standardblend</code> did, and <code>standardblend</code> behaviour can easily be replicated by passing <code>nFocusResults=1</code>, 
+         * Specifies the number of results (must be &lt;= nResults) within the results set which will have a focus. Defaults to <code>nResults</code>.
+         * This allows you to run autosuggest with a mix of focussed and unfocussed results, to give you a "blend" of the two. This is exactly what the old V2
+         * <code>standardblend</code> did, and <code>standardblend</code> behaviour can easily be replicated by passing <code>nFocusResults=1</code>,
          * which will return just one focussed result and the rest unfocussed.
-         * 
+         *
          * @param n number of results within the results set which will have a focus
          * @return a {@link Builder} instance suitable for invoking a <code>autosuggest</code> API request
          */
@@ -95,11 +97,11 @@ public class AutosuggestRequest extends Request<Autosuggest> {
             this.nFocusResults = String.valueOf(n);
             return this;
         }
-        
+
         /**
-         * Restrict autosuggest results to a circle, specified by <code>Coordinates</code> representing the centre of the circle, plus the 
+         * Restrict autosuggest results to a circle, specified by <code>Coordinates</code> representing the centre of the circle, plus the
          * <code>radius</code> in kilometres. For convenience, longitude is allowed to wrap around 180 degrees. For example 181 is equivalent to -179.
-         * 
+         *
          * @param centre the centre of the circle
          * @param radius the radius of the circle in kilometres
          * @return a {@link Builder} instance suitable for invoking a <code>autosuggest</code> API request
@@ -108,24 +110,28 @@ public class AutosuggestRequest extends Request<Autosuggest> {
             this.clipToCircle = String.valueOf(centre.lat) + "," + String.valueOf(centre.lng) + "," + String.valueOf(radius);
             return this;
         }
-        
+
         /**
-         * Restrict autosuggest results to a polygon, specified by a collection of <code>Coordinates</code>. The polygon should be closed, 
-         * i.e. the first element should be repeated as the last element; also the list should contain at least 4 entries. The API is currently limited to 
+         * Restrict autosuggest results to a polygon, specified by a collection of <code>Coordinates</code>. The polygon should be closed,
+         * i.e. the first element should be repeated as the last element; also the list should contain at least 4 entries. The API is currently limited to
          * accepting up to 25 pairs.
-         * 
+         *
          * @param polygon the polygon to clip results too
          * @return a {@link Builder} instance suitable for invoking a <code>autosuggest</code> API request
          */
         public Builder clipToPolygon(Coordinates... polygon) {
-            this.clipToPolygon = Arrays.stream(polygon).map(p -> String.valueOf(p.lat) + "," + String.valueOf(p.lng))
-                    .collect(Collectors.joining(","));
+            List<String> coordinatesList = new ArrayList<>();
+            for (Coordinates coordinates : polygon) {
+                coordinatesList.add(String.valueOf(coordinates.lat));
+                coordinatesList.add(String.valueOf(coordinates.lng));
+            }
+            this.clipToPolygon = join(",", coordinatesList.toArray(new String[0]));
             return this;
         }
-        
+
         /**
-         * Restrict autosuggest results to a <code>BoundingBox</code>. 
-         * 
+         * Restrict autosuggest results to a <code>BoundingBox</code>.
+         *
          * @param boundingBox <code>BoundingBox</code> to clip results too
          * @return a {@link Builder} instance suitable for invoking a <code>autosuggest</code> API request
          */
@@ -134,26 +140,26 @@ public class AutosuggestRequest extends Request<Autosuggest> {
                     String.valueOf(boundingBox.ne.lat) + "," + String.valueOf(boundingBox.ne.lng);
             return this;
         }
-        
+
         /**
-         * Restricts autosuggest to only return results inside the countries specified by comma-separated list of uppercase ISO 3166-1 alpha-2 country codes 
-         * (for example, to restrict to Belgium and the UK, use <code>clipToCountry("GB", "BE")</code>. <code>clipToCountry</code> will also accept lowercase 
-         * country codes. Entries must be two a-z letters. WARNING: If the two-letter code does not correspond to a country, there is no error: API simply 
+         * Restricts autosuggest to only return results inside the countries specified by comma-separated list of uppercase ISO 3166-1 alpha-2 country codes
+         * (for example, to restrict to Belgium and the UK, use <code>clipToCountry("GB", "BE")</code>. <code>clipToCountry</code> will also accept lowercase
+         * country codes. Entries must be two a-z letters. WARNING: If the two-letter code does not correspond to a country, there is no error: API simply
          * returns no results.
-         * 
+         *
          * @param countryCodes countries to clip results too
          * @return a {@link Builder} instance suitable for invoking a <code>autosuggest</code> API request
          */
         public Builder clipToCountry(String... countryCodes) {
-            this.clipToCountry = String.join(",", countryCodes);
+            this.clipToCountry = join(",", countryCodes);
             return this;
         }
-        
+
         /**
-         * For normal text input, specifies a fallback language, which will help guide AutoSuggest if the input is particularly messy. If specified, 
-         * this parameter must be a supported 3 word address language as an ISO 639-1 2 letter code. For voice input (see voice section), 
+         * For normal text input, specifies a fallback language, which will help guide AutoSuggest if the input is particularly messy. If specified,
+         * this parameter must be a supported 3 word address language as an ISO 639-1 2 letter code. For voice input (see voice section),
          * language must always be specified.
-         * 
+         *
          * @param language the fallback language
          * @return a {@link Builder} instance suitable for invoking a <code>autosuggest</code> API request
          */
@@ -161,11 +167,11 @@ public class AutosuggestRequest extends Request<Autosuggest> {
             this.language = language;
             return this;
         }
-        
+
         /**
-         * For power users, used to specify voice input mode. Can be <code>AutosuggestInputType.TEXT</code> (default), <code>AutosuggestInputType.VOCON_HYBRID</code> 
+         * For power users, used to specify voice input mode. Can be <code>AutosuggestInputType.TEXT</code> (default), <code>AutosuggestInputType.VOCON_HYBRID</code>
          * or <code>AutosuggestInputType.NMDP_ASR</code>. See voice recognition section within the developer docs for more details https://docs.what3words.com/api/v3/#voice.
-         * 
+         *
          * @param type the AutosuggestInputType
          * @return a {@link Builder} instance suitable for invoking a <code>autosuggest</code> API request
          */
@@ -173,7 +179,7 @@ public class AutosuggestRequest extends Request<Autosuggest> {
             this.inputType = type.toString();
             return this;
         }
-        
+
         public Builder preferLand(boolean preferLand) {
             this.preferLand = Boolean.toString(preferLand);
             return this;
@@ -181,11 +187,25 @@ public class AutosuggestRequest extends Request<Autosuggest> {
 
         /**
          * Execute the API call as represented by the values set within this {@link Builder}
-         * 
+         *
          * @return an {@link APIResponse} representing the response from the what3words API
          */
         public Autosuggest execute() {
             return new AutosuggestRequest(this).execute();
+        }
+
+        private static String join(String separator, String... values) {
+            if (values == null || values.length == 0) return "";
+            StringBuilder sb = new StringBuilder();
+            int end = 0;
+            for (String s : values) {
+                if (s != null) {
+                    sb.append(s);
+                    end = sb.length();
+                    sb.append(separator);
+                }
+            }
+            return sb.substring(0, end);
         }
     }
 }


### PR DESCRIPTION
Java wrapper is a dependency of our Android wrapper and using streams or String.join was limiting our portability to Android API 19.