### PR TITLE
Change target from Java 1.8 to Java 1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+		<maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
 	</properties>
 
 	<dependencies>
@@ -116,6 +116,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.2.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/src/main/java/com/what3words/javawrapper/request/AutosuggestRequest.java
+++ b/src/main/java/com/what3words/javawrapper/request/AutosuggestRequest.java
@@ -3,7 +3,6 @@ package com.what3words.javawrapper.request;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import com.what3words.javawrapper.What3WordsV3;
 import com.what3words.javawrapper.response.APIResponse;


### PR DESCRIPTION
Minimal changes to make the library more portable. Most of the work already done, but the target needed changing and an unused reference removing.

Addresses issue #7 
