### PR TITLE
API/SDK compatibility refactor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ workflows:
           context:
             - maven-sign
           name: Build, run tests, sonar and push to maven staging
-#          filters:
-#            branches:
-#              only:
-#                - dev
+          filters:
+            branches:
+              only:
+                - dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,7 @@ workflows:
           context:
             - maven-sign
           name: Build, run tests, sonar and push to maven staging
-          filters:
-            branches:
-              only:
-                - dev
+#          filters:
+#            branches:
+#              only:
+#                - dev

--- a/src/main/java/com/what3words/javawrapper/What3WordsJavaWrapper.java
+++ b/src/main/java/com/what3words/javawrapper/What3WordsJavaWrapper.java
@@ -8,7 +8,7 @@ import retrofit2.Retrofit;
  * Instances of the What3WordsV3 class provide access to Version 3 of the what3words API.
  */
 
-public interface What3WordsWrapper {
+public interface What3WordsJavaWrapper {
     ConvertTo3WARequest.Builder convertTo3wa(Coordinates coordinates);
     ConvertToCoordinatesRequest.Builder convertToCoordinates(String words);
     AutosuggestRequest.Builder autosuggest(String input);

--- a/src/main/java/com/what3words/javawrapper/What3WordsV3.java
+++ b/src/main/java/com/what3words/javawrapper/What3WordsV3.java
@@ -7,14 +7,13 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.what3words.javawrapper.request.*;
-import com.what3words.javawrapper.response.AutosuggestSelection;
 import com.what3words.javawrapper.services.What3WordsV3Service;
 
 import okhttp3.OkHttpClient;
 import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
 
-public class What3WordsV3 implements What3WordsWrapper {
+public class What3WordsV3 implements What3WordsJavaWrapper {
     private static String DEFAULT_ENDPOINT = "https://api.what3words.com/v3/";
 
     public static final String HEADER_CONTENT_TYPE = "Content-Type";

--- a/src/main/java/com/what3words/javawrapper/request/AbstractBuilder.java
+++ b/src/main/java/com/what3words/javawrapper/request/AbstractBuilder.java
@@ -1,7 +1,6 @@
 package com.what3words.javawrapper.request;
 
-import com.what3words.javawrapper.What3WordsV3;
-import com.what3words.javawrapper.What3WordsWrapper;
+import com.what3words.javawrapper.What3WordsJavaWrapper;
 import com.what3words.javawrapper.request.ConvertTo3WARequest.Builder;
 import com.what3words.javawrapper.response.APIResponse;
 
@@ -10,9 +9,9 @@ import com.what3words.javawrapper.response.APIResponse;
  * before calling <code>execute()</code> to invoke the API request
  */
 public abstract class AbstractBuilder<T> {
-    protected What3WordsWrapper api;
+    protected What3WordsJavaWrapper api;
     
-    protected AbstractBuilder(What3WordsWrapper api) {
+    protected AbstractBuilder(What3WordsJavaWrapper api) {
         this.api = api;
     }
     

--- a/src/main/java/com/what3words/javawrapper/request/AutosuggestRequest.java
+++ b/src/main/java/com/what3words/javawrapper/request/AutosuggestRequest.java
@@ -5,6 +5,7 @@ import com.what3words.javawrapper.response.APIResponse;
 import com.what3words.javawrapper.response.Autosuggest;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 public class AutosuggestRequest extends Request<Autosuggest> {
@@ -52,10 +53,12 @@ public class AutosuggestRequest extends Request<Autosuggest> {
         private String inputType;
         private String language;
         private String preferLand;
+        private AutosuggestOptions options;
 
         public Builder(What3WordsJavaWrapper api, String input) {
             super(api);
             this.input = input;
+            this.options = new AutosuggestOptions();
         }
 
         /**
@@ -67,6 +70,7 @@ public class AutosuggestRequest extends Request<Autosuggest> {
          */
         public Builder nResults(int n) {
             this.nResults = String.valueOf(n);
+            this.options.setNResults(n);
             return this;
         }
 
@@ -79,6 +83,7 @@ public class AutosuggestRequest extends Request<Autosuggest> {
          */
         public Builder focus(Coordinates coordinates) {
             this.focus = String.valueOf(coordinates.lat) + "," + String.valueOf(coordinates.lng);
+            this.options.setFocus(coordinates);
             return this;
         }
 
@@ -93,6 +98,7 @@ public class AutosuggestRequest extends Request<Autosuggest> {
          */
         public Builder nFocusResults(int n) {
             this.nFocusResults = String.valueOf(n);
+            this.options.setNFocusResults(n);
             return this;
         }
 
@@ -106,6 +112,8 @@ public class AutosuggestRequest extends Request<Autosuggest> {
          */
         public Builder clipToCircle(Coordinates centre, double radius) {
             this.clipToCircle = String.valueOf(centre.lat) + "," + String.valueOf(centre.lng) + "," + String.valueOf(radius);
+            this.options.setClipToCircle(centre);
+            this.options.setClipToCircleRadius(radius);
             return this;
         }
 
@@ -124,6 +132,7 @@ public class AutosuggestRequest extends Request<Autosuggest> {
                 coordinatesList.add(String.valueOf(coordinates.lng));
             }
             this.clipToPolygon = join(",", coordinatesList.toArray(new String[0]));
+            this.options.setClipToPolygon(Arrays.asList(polygon));
             return this;
         }
 
@@ -136,6 +145,7 @@ public class AutosuggestRequest extends Request<Autosuggest> {
         public Builder clipToBoundingBox(BoundingBox boundingBox) {
             this.clipToBoundingBox = String.valueOf(boundingBox.sw.lat) + "," + String.valueOf(boundingBox.sw.lng) + "," +
                     String.valueOf(boundingBox.ne.lat) + "," + String.valueOf(boundingBox.ne.lng);
+            this.options.setClipToBoundingBox(boundingBox);
             return this;
         }
 
@@ -150,6 +160,7 @@ public class AutosuggestRequest extends Request<Autosuggest> {
          */
         public Builder clipToCountry(String... countryCodes) {
             this.clipToCountry = join(",", countryCodes);
+            this.options.setClipToCountry(Arrays.asList(countryCodes));
             return this;
         }
 
@@ -163,6 +174,7 @@ public class AutosuggestRequest extends Request<Autosuggest> {
          */
         public Builder language(String language) {
             this.language = language;
+            this.options.setLanguage(language);
             return this;
         }
 
@@ -175,11 +187,13 @@ public class AutosuggestRequest extends Request<Autosuggest> {
          */
         public Builder inputType(AutosuggestInputType type) {
             this.inputType = type.toString();
+            this.options.setInputType(type);
             return this;
         }
 
         public Builder preferLand(boolean preferLand) {
             this.preferLand = Boolean.toString(preferLand);
+            this.options.setPreferLand(preferLand);
             return this;
         }
 
@@ -215,6 +229,10 @@ public class AutosuggestRequest extends Request<Autosuggest> {
          */
         public Autosuggest execute() {
             return new AutosuggestRequest(this).execute();
+        }
+
+        public AutosuggestOptions getOptions() {
+            return this.options;
         }
 
         private static String join(String separator, String... values) {

--- a/src/main/java/com/what3words/javawrapper/request/AutosuggestRequest.java
+++ b/src/main/java/com/what3words/javawrapper/request/AutosuggestRequest.java
@@ -1,6 +1,6 @@
 package com.what3words.javawrapper.request;
 
-import com.what3words.javawrapper.What3WordsV3;
+import com.what3words.javawrapper.What3WordsJavaWrapper;
 import com.what3words.javawrapper.response.APIResponse;
 import com.what3words.javawrapper.response.Autosuggest;
 
@@ -53,7 +53,7 @@ public class AutosuggestRequest extends Request<Autosuggest> {
         private String language;
         private String preferLand;
 
-        public Builder(What3WordsV3 api, String input) {
+        public Builder(What3WordsJavaWrapper api, String input) {
             super(api);
             this.input = input;
         }

--- a/src/main/java/com/what3words/javawrapper/request/AutosuggestSelectionRequest.java
+++ b/src/main/java/com/what3words/javawrapper/request/AutosuggestSelectionRequest.java
@@ -1,8 +1,7 @@
 package com.what3words.javawrapper.request;
 
 import com.google.gson.stream.MalformedJsonException;
-import com.what3words.javawrapper.What3WordsV3;
-import com.what3words.javawrapper.What3WordsWrapper;
+import com.what3words.javawrapper.What3WordsJavaWrapper;
 import com.what3words.javawrapper.response.APIError;
 import com.what3words.javawrapper.response.APIResponse;
 import com.what3words.javawrapper.response.AutosuggestSelection;
@@ -16,7 +15,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class AutosuggestSelectionRequest {
-    protected What3WordsWrapper api;
+    protected What3WordsJavaWrapper api;
     private String rawInput;
     private String selection;
     private String rank;
@@ -132,7 +131,7 @@ public class AutosuggestSelectionRequest {
         private String language;
         private String preferLand;
 
-        public Builder(What3WordsWrapper api, String rawInput, String selection, int rank, SourceApi sourceApi) {
+        public Builder(What3WordsJavaWrapper api, String rawInput, String selection, int rank, SourceApi sourceApi) {
             super(api);
             this.rawInput = rawInput;
             this.selection = selection;

--- a/src/main/java/com/what3words/javawrapper/request/AutosuggestWithCoordinatesRequest.java
+++ b/src/main/java/com/what3words/javawrapper/request/AutosuggestWithCoordinatesRequest.java
@@ -3,7 +3,7 @@ package com.what3words.javawrapper.request;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.what3words.javawrapper.What3WordsV3;
+import com.what3words.javawrapper.What3WordsJavaWrapper;
 import com.what3words.javawrapper.response.APIResponse;
 import com.what3words.javawrapper.response.AutosuggestWithCoordinates;
 
@@ -53,7 +53,7 @@ public class AutosuggestWithCoordinatesRequest extends Request<AutosuggestWithCo
         private String language;
         private String preferLand;
 
-        public Builder(What3WordsV3 api, String input) {
+        public Builder(What3WordsJavaWrapper api, String input) {
             super(api);
             this.input = input;
         }

--- a/src/main/java/com/what3words/javawrapper/request/AutosuggestWithCoordinatesRequest.java
+++ b/src/main/java/com/what3words/javawrapper/request/AutosuggestWithCoordinatesRequest.java
@@ -1,6 +1,7 @@
 package com.what3words.javawrapper.request;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 import com.what3words.javawrapper.What3WordsJavaWrapper;
@@ -52,10 +53,12 @@ public class AutosuggestWithCoordinatesRequest extends Request<AutosuggestWithCo
         private String inputType;
         private String language;
         private String preferLand;
+        private AutosuggestOptions options;
 
         public Builder(What3WordsJavaWrapper api, String input) {
             super(api);
             this.input = input;
+            this.options = new AutosuggestOptions();
         }
 
         /**
@@ -67,6 +70,7 @@ public class AutosuggestWithCoordinatesRequest extends Request<AutosuggestWithCo
          */
         public Builder nResults(int n) {
             this.nResults = String.valueOf(n);
+            this.options.setNResults(n);
             return this;
         }
 
@@ -79,6 +83,7 @@ public class AutosuggestWithCoordinatesRequest extends Request<AutosuggestWithCo
          */
         public Builder focus(Coordinates coordinates) {
             this.focus = String.valueOf(coordinates.lat) + "," + String.valueOf(coordinates.lng);
+            this.options.setFocus(coordinates);
             return this;
         }
 
@@ -93,6 +98,7 @@ public class AutosuggestWithCoordinatesRequest extends Request<AutosuggestWithCo
          */
         public Builder nFocusResults(int n) {
             this.nFocusResults = String.valueOf(n);
+            this.options.setNFocusResults(n);
             return this;
         }
 
@@ -106,6 +112,8 @@ public class AutosuggestWithCoordinatesRequest extends Request<AutosuggestWithCo
          */
         public Builder clipToCircle(Coordinates centre, double radius) {
             this.clipToCircle = String.valueOf(centre.lat) + "," + String.valueOf(centre.lng) + "," + String.valueOf(radius);
+            this.options.setClipToCircle(centre);
+            this.options.setClipToCircleRadius(radius);
             return this;
         }
 
@@ -124,6 +132,7 @@ public class AutosuggestWithCoordinatesRequest extends Request<AutosuggestWithCo
                 coordinatesList.add(String.valueOf(coordinates.lng));
             }
             this.clipToPolygon = join(",", coordinatesList.toArray(new String[0]));
+            this.options.setClipToPolygon(Arrays.asList(polygon));
             return this;
         }
 
@@ -136,6 +145,7 @@ public class AutosuggestWithCoordinatesRequest extends Request<AutosuggestWithCo
         public Builder clipToBoundingBox(BoundingBox boundingBox) {
             this.clipToBoundingBox = String.valueOf(boundingBox.sw.lat) + "," + String.valueOf(boundingBox.sw.lng) + "," +
                     String.valueOf(boundingBox.ne.lat) + "," + String.valueOf(boundingBox.ne.lng);
+            this.options.setClipToBoundingBox(boundingBox);
             return this;
         }
 
@@ -150,6 +160,7 @@ public class AutosuggestWithCoordinatesRequest extends Request<AutosuggestWithCo
          */
         public Builder clipToCountry(String... countryCodes) {
             this.clipToCountry = join(",", countryCodes);
+            this.options.setClipToCountry(Arrays.asList(countryCodes));
             return this;
         }
 
@@ -163,6 +174,7 @@ public class AutosuggestWithCoordinatesRequest extends Request<AutosuggestWithCo
          */
         public Builder language(String language) {
             this.language = language;
+            this.options.setLanguage(language);
             return this;
         }
 
@@ -175,11 +187,13 @@ public class AutosuggestWithCoordinatesRequest extends Request<AutosuggestWithCo
          */
         public Builder inputType(AutosuggestInputType type) {
             this.inputType = type.toString();
+            this.options.setInputType(type);
             return this;
         }
 
         public Builder preferLand(boolean preferLand) {
             this.preferLand = Boolean.toString(preferLand);
+            this.options.setPreferLand(preferLand);
             return this;
         }
 
@@ -206,6 +220,10 @@ public class AutosuggestWithCoordinatesRequest extends Request<AutosuggestWithCo
             if (options.getInputType() != null) inputType(options.getInputType());
             if (options.getPreferLand() != null) preferLand(options.getPreferLand());
             return this;
+        }
+
+        public AutosuggestOptions getOptions() {
+            return this.options;
         }
 
         /**

--- a/src/main/java/com/what3words/javawrapper/request/AvailableLanguagesRequest.java
+++ b/src/main/java/com/what3words/javawrapper/request/AvailableLanguagesRequest.java
@@ -1,6 +1,6 @@
 package com.what3words.javawrapper.request;
 
-import com.what3words.javawrapper.What3WordsV3;
+import com.what3words.javawrapper.What3WordsJavaWrapper;
 import com.what3words.javawrapper.response.APIResponse;
 import com.what3words.javawrapper.response.AvailableLanguages;
 
@@ -14,7 +14,7 @@ public class AvailableLanguagesRequest extends Request<AvailableLanguages> {
     }
 
     public static class Builder extends AbstractBuilder<AvailableLanguages> {
-        public Builder(What3WordsV3 api) {
+        public Builder(What3WordsJavaWrapper api) {
             super(api);
         }
 

--- a/src/main/java/com/what3words/javawrapper/request/ConvertTo3WARequest.java
+++ b/src/main/java/com/what3words/javawrapper/request/ConvertTo3WARequest.java
@@ -1,6 +1,6 @@
 package com.what3words.javawrapper.request;
 
-import com.what3words.javawrapper.What3WordsV3;
+import com.what3words.javawrapper.What3WordsJavaWrapper;
 import com.what3words.javawrapper.response.ConvertTo3WA;
 
 public class ConvertTo3WARequest extends Request<ConvertTo3WA> {
@@ -21,7 +21,7 @@ public class ConvertTo3WARequest extends Request<ConvertTo3WA> {
         private String coordinates;
         private String language;
         
-        public Builder(What3WordsV3 api, Coordinates coordinates) {
+        public Builder(What3WordsJavaWrapper api, Coordinates coordinates) {
             super(api);
             this.coordinates = String.valueOf(coordinates.lat) + "," + String.valueOf(coordinates.lng);
         }

--- a/src/main/java/com/what3words/javawrapper/request/ConvertTo3WARequest.java
+++ b/src/main/java/com/what3words/javawrapper/request/ConvertTo3WARequest.java
@@ -30,7 +30,11 @@ public class ConvertTo3WARequest extends Request<ConvertTo3WA> {
             this.language = language;
             return this;
         }
-        
+
+        public String getLanguage() {
+            return language;
+        }
+
         public ConvertTo3WA execute() {
             return new ConvertTo3WARequest(this).execute();
         }

--- a/src/main/java/com/what3words/javawrapper/request/ConvertToCoordinatesRequest.java
+++ b/src/main/java/com/what3words/javawrapper/request/ConvertToCoordinatesRequest.java
@@ -1,6 +1,6 @@
 package com.what3words.javawrapper.request;
 
-import com.what3words.javawrapper.What3WordsV3;
+import com.what3words.javawrapper.What3WordsJavaWrapper;
 import com.what3words.javawrapper.response.ConvertToCoordinates;
 
 public class ConvertToCoordinatesRequest extends Request<ConvertToCoordinates> {
@@ -18,7 +18,7 @@ public class ConvertToCoordinatesRequest extends Request<ConvertToCoordinates> {
     public static class Builder extends AbstractBuilder<ConvertToCoordinates> {
         private String words;
         
-        public Builder(What3WordsV3 api, String words) {
+        public Builder(What3WordsJavaWrapper api, String words) {
             super(api);
             this.words = words;
         }

--- a/src/main/java/com/what3words/javawrapper/request/GridSectionGeoJsonRequest.java
+++ b/src/main/java/com/what3words/javawrapper/request/GridSectionGeoJsonRequest.java
@@ -1,6 +1,6 @@
 package com.what3words.javawrapper.request;
 
-import com.what3words.javawrapper.What3WordsV3;
+import com.what3words.javawrapper.What3WordsJavaWrapper;
 import com.what3words.javawrapper.response.GridSectionGeoJson;
 
 public class GridSectionGeoJsonRequest extends Request<GridSectionGeoJson> {
@@ -18,7 +18,7 @@ public class GridSectionGeoJsonRequest extends Request<GridSectionGeoJson> {
     public static class Builder extends AbstractBuilder<GridSectionGeoJson> {
         private String boundingBox;
 
-        public Builder(What3WordsV3 api, BoundingBox boundingBox) {
+        public Builder(What3WordsJavaWrapper api, BoundingBox boundingBox) {
             super(api);
             this.boundingBox = String.valueOf(boundingBox.sw.lat) + "," + String.valueOf(boundingBox.sw.lng) + "," +
                     String.valueOf(boundingBox.ne.lat) + "," + String.valueOf(boundingBox.ne.lng);

--- a/src/main/java/com/what3words/javawrapper/request/GridSectionRequest.java
+++ b/src/main/java/com/what3words/javawrapper/request/GridSectionRequest.java
@@ -1,9 +1,7 @@
 package com.what3words.javawrapper.request;
 
-import com.what3words.javawrapper.What3WordsV3;
-import com.what3words.javawrapper.response.APIResponse;
+import com.what3words.javawrapper.What3WordsJavaWrapper;
 import com.what3words.javawrapper.response.GridSection;
-import com.what3words.javawrapper.response.GridSectionGeoJson;
 
 public class GridSectionRequest extends Request<GridSection> {
     private String boundingBox;
@@ -20,7 +18,7 @@ public class GridSectionRequest extends Request<GridSection> {
     public static class Builder extends AbstractBuilder<GridSection> {
         private String boundingBox;
         
-        public Builder(What3WordsV3 api, BoundingBox boundingBox) {
+        public Builder(What3WordsJavaWrapper api, BoundingBox boundingBox) {
             super(api);
             this.boundingBox = String.valueOf(boundingBox.sw.lat) + "," + String.valueOf(boundingBox.sw.lng) + "," +
                     String.valueOf(boundingBox.ne.lat) + "," + String.valueOf(boundingBox.ne.lng);

--- a/src/main/java/com/what3words/javawrapper/request/Request.java
+++ b/src/main/java/com/what3words/javawrapper/request/Request.java
@@ -4,8 +4,7 @@ import java.io.IOException;
 import java.lang.annotation.Annotation;
 
 import com.google.gson.stream.MalformedJsonException;
-import com.what3words.javawrapper.What3WordsV3;
-import com.what3words.javawrapper.What3WordsWrapper;
+import com.what3words.javawrapper.What3WordsJavaWrapper;
 import com.what3words.javawrapper.response.APIError;
 import com.what3words.javawrapper.response.APIResponse;
 import com.what3words.javawrapper.response.APIResponse.What3WordsError;
@@ -17,9 +16,9 @@ import retrofit2.Call;
 import retrofit2.Converter;
 
 public class Request<T extends Response<T>> {
-    protected What3WordsWrapper api;
+    protected What3WordsJavaWrapper api;
     
-    protected Request(What3WordsWrapper api) {
+    protected Request(What3WordsJavaWrapper api) {
         this.api = api;
     }
 

--- a/src/main/java/com/what3words/javawrapper/response/APIResponse.java
+++ b/src/main/java/com/what3words/javawrapper/response/APIResponse.java
@@ -73,7 +73,9 @@ public class APIResponse<T> {
         INVALID_API_VERSION("InvalidApiVersion"),
         INVALID_REFERRER("InvalidReferrer"),
         INVALID_IP_ADDRESS("InvalidIpAddress"),
-        INVALID_APP_CREDENTIALS("InvalidAppCredentials");
+        INVALID_APP_CREDENTIALS("InvalidAppCredentials"),
+        
+        SDK_ERROR("SdkError");
 
         private final String key;
         private String message;

--- a/src/main/java/com/what3words/javawrapper/response/Autosuggest.java
+++ b/src/main/java/com/what3words/javawrapper/response/Autosuggest.java
@@ -7,10 +7,15 @@ import com.google.gson.GsonBuilder;
 public class Autosuggest extends Response<Autosuggest> {
     private List<Suggestion> suggestions = null;
 
+    public Autosuggest(List<Suggestion> suggestions) {
+        this.suggestions = suggestions;
+    }
+
     public List<Suggestion> getSuggestions() {
         return suggestions;
     }
 
+    @Deprecated
     public void setSuggestions(List<Suggestion> suggestions) {
         this.suggestions = suggestions;
     }

--- a/src/main/java/com/what3words/javawrapper/response/Autosuggest.java
+++ b/src/main/java/com/what3words/javawrapper/response/Autosuggest.java
@@ -7,6 +7,10 @@ import com.google.gson.GsonBuilder;
 public class Autosuggest extends Response<Autosuggest> {
     private List<Suggestion> suggestions = null;
 
+    public Autosuggest() {
+
+    }
+
     public Autosuggest(List<Suggestion> suggestions) {
         this.suggestions = suggestions;
     }
@@ -19,7 +23,7 @@ public class Autosuggest extends Response<Autosuggest> {
     public void setSuggestions(List<Suggestion> suggestions) {
         this.suggestions = suggestions;
     }
-    
+
     public String toString() {
         return new GsonBuilder().setPrettyPrinting().create().toJson(this);
     }

--- a/src/main/java/com/what3words/javawrapper/response/AutosuggestWithCoordinates.java
+++ b/src/main/java/com/what3words/javawrapper/response/AutosuggestWithCoordinates.java
@@ -8,10 +8,15 @@ public class AutosuggestWithCoordinates extends Response<AutosuggestWithCoordina
 	
 	private List<SuggestionWithCoordinates> suggestions = null;
 
+	public AutosuggestWithCoordinates(List<SuggestionWithCoordinates> suggestions) {
+		this.suggestions = suggestions;
+	}
+
 	public List<SuggestionWithCoordinates> getSuggestions() {
 		return suggestions;
 	}
 
+	@Deprecated
 	public void setSuggestions(List<SuggestionWithCoordinates> suggestions) {
 		this.suggestions = suggestions;
 	}

--- a/src/main/java/com/what3words/javawrapper/response/AutosuggestWithCoordinates.java
+++ b/src/main/java/com/what3words/javawrapper/response/AutosuggestWithCoordinates.java
@@ -8,6 +8,10 @@ public class AutosuggestWithCoordinates extends Response<AutosuggestWithCoordina
 	
 	private List<SuggestionWithCoordinates> suggestions = null;
 
+	public AutosuggestWithCoordinates() {
+
+	}
+
 	public AutosuggestWithCoordinates(List<SuggestionWithCoordinates> suggestions) {
 		this.suggestions = suggestions;
 	}

--- a/src/main/java/com/what3words/javawrapper/response/AvailableLanguages.java
+++ b/src/main/java/com/what3words/javawrapper/response/AvailableLanguages.java
@@ -7,6 +7,10 @@ import com.google.gson.GsonBuilder;
 public class AvailableLanguages extends Response<AvailableLanguages> {
     private List<Language> languages = null;
 
+    public AvailableLanguages(List<Language> languages) {
+        this.languages = languages;
+    }
+
     public List<Language> getLanguages() {
         return languages;
     }

--- a/src/main/java/com/what3words/javawrapper/response/ConvertTo3WA.java
+++ b/src/main/java/com/what3words/javawrapper/response/ConvertTo3WA.java
@@ -11,6 +11,9 @@ public class ConvertTo3WA extends Response<ConvertTo3WA> {
     private String language;
     private String map;
 
+    public ConvertTo3WA() {
+    }
+
     public ConvertTo3WA(String country, Square square, String nearestPlace, Coordinates coordinates, String words, String language, String map) {
         this.country = country;
         this.square = square;
@@ -48,7 +51,7 @@ public class ConvertTo3WA extends Response<ConvertTo3WA> {
     public String getMap() {
         return map;
     }
-    
+
     public String toString() {
         return new GsonBuilder().setPrettyPrinting().create().toJson(this);
     }

--- a/src/main/java/com/what3words/javawrapper/response/ConvertTo3WA.java
+++ b/src/main/java/com/what3words/javawrapper/response/ConvertTo3WA.java
@@ -11,6 +11,16 @@ public class ConvertTo3WA extends Response<ConvertTo3WA> {
     private String language;
     private String map;
 
+    public ConvertTo3WA(String country, Square square, String nearestPlace, Coordinates coordinates, String words, String language, String map) {
+        this.country = country;
+        this.square = square;
+        this.nearestPlace = nearestPlace;
+        this.coordinates = coordinates;
+        this.words = words;
+        this.language = language;
+        this.map = map;
+    }
+
     public String getCountry() {
         return country;
     }

--- a/src/main/java/com/what3words/javawrapper/response/ConvertToCoordinates.java
+++ b/src/main/java/com/what3words/javawrapper/response/ConvertToCoordinates.java
@@ -11,6 +11,16 @@ public class ConvertToCoordinates extends Response<ConvertToCoordinates> {
     private String language;
     private String map;
 
+    public ConvertToCoordinates(String country, Square square, String nearestPlace, Coordinates coordinates, String words, String language, String map) {
+        this.country = country;
+        this.square = square;
+        this.nearestPlace = nearestPlace;
+        this.coordinates = coordinates;
+        this.words = words;
+        this.language = language;
+        this.map = map;
+    }
+
     public String getCountry() {
         return country;
     }

--- a/src/main/java/com/what3words/javawrapper/response/ConvertToCoordinates.java
+++ b/src/main/java/com/what3words/javawrapper/response/ConvertToCoordinates.java
@@ -11,6 +11,9 @@ public class ConvertToCoordinates extends Response<ConvertToCoordinates> {
     private String language;
     private String map;
 
+    public ConvertToCoordinates() {
+    }
+
     public ConvertToCoordinates(String country, Square square, String nearestPlace, Coordinates coordinates, String words, String language, String map) {
         this.country = country;
         this.square = square;

--- a/src/main/java/com/what3words/javawrapper/response/Coordinates.java
+++ b/src/main/java/com/what3words/javawrapper/response/Coordinates.java
@@ -4,7 +4,7 @@ public class Coordinates {
     private double lng;
     private double lat;
 
-    protected Coordinates(double lat, double lng) {
+    public Coordinates(double lat, double lng) {
         this.lng = lng;
         this.lat = lat;
     }

--- a/src/main/java/com/what3words/javawrapper/response/GridSection.java
+++ b/src/main/java/com/what3words/javawrapper/response/GridSection.java
@@ -7,6 +7,9 @@ import com.google.gson.GsonBuilder;
 public class GridSection extends Response<GridSection> {
     private List<Line> lines = null;
 
+    public GridSection() {
+    }
+
     public GridSection(List<Line> lines) {
         this.lines = lines;
     }

--- a/src/main/java/com/what3words/javawrapper/response/GridSection.java
+++ b/src/main/java/com/what3words/javawrapper/response/GridSection.java
@@ -7,10 +7,14 @@ import com.google.gson.GsonBuilder;
 public class GridSection extends Response<GridSection> {
     private List<Line> lines = null;
 
+    public GridSection(List<Line> lines) {
+        this.lines = lines;
+    }
+
     public List<Line> getLines() {
         return lines;
     }
-    
+
     public String toString() {
         return new GsonBuilder().setPrettyPrinting().create().toJson(this);
     }

--- a/src/main/java/com/what3words/javawrapper/response/GridSectionGeoJson.java
+++ b/src/main/java/com/what3words/javawrapper/response/GridSectionGeoJson.java
@@ -7,6 +7,9 @@ public class GridSectionGeoJson extends Response<GridSectionGeoJson> {
     private JsonArray features = null;
     private String type = null;
 
+    public GridSectionGeoJson() {
+    }
+
     public GridSectionGeoJson(JsonArray features, String type) {
         this.features = features;
         this.type = type;

--- a/src/main/java/com/what3words/javawrapper/response/GridSectionGeoJson.java
+++ b/src/main/java/com/what3words/javawrapper/response/GridSectionGeoJson.java
@@ -7,6 +7,11 @@ public class GridSectionGeoJson extends Response<GridSectionGeoJson> {
     private JsonArray features = null;
     private String type = null;
 
+    public GridSectionGeoJson(JsonArray features, String type) {
+        this.features = features;
+        this.type = type;
+    }
+
     public JsonArray getFeatures() {
         return features;
     }

--- a/src/main/java/com/what3words/javawrapper/response/Language.java
+++ b/src/main/java/com/what3words/javawrapper/response/Language.java
@@ -5,6 +5,12 @@ public class Language {
     private String name;
     private String nativeName;
 
+    public Language(String code, String name, String nativeName) {
+        this.code = code;
+        this.name = name;
+        this.nativeName = nativeName;
+    }
+
     public String getCode() {
         return code;
     }

--- a/src/main/java/com/what3words/javawrapper/response/Square.java
+++ b/src/main/java/com/what3words/javawrapper/response/Square.java
@@ -1,5 +1,7 @@
 package com.what3words.javawrapper.response;
 
+import com.what3words.javawrapper.request.BoundingBox;
+
 public class Square {
     private Coordinates southwest;
     private Coordinates northeast;
@@ -7,6 +9,11 @@ public class Square {
     public Square(double neLat, double neLng, double swLat, double swLng) {
         southwest = new Coordinates(swLat, swLng);
         northeast = new Coordinates(neLat, neLng);
+    }
+
+    public Square(BoundingBox box) {
+        southwest = new Coordinates(box.sw.lat, box.sw.lng);
+        northeast = new Coordinates(box.ne.lat, box.ne.lng);
     }
 
     public Coordinates getSouthwest() {

--- a/src/test/java/com/what3words/javawrapper/AvailableLanguagesTest.java
+++ b/src/test/java/com/what3words/javawrapper/AvailableLanguagesTest.java
@@ -1,0 +1,18 @@
+package com.what3words.javawrapper;
+
+import com.what3words.javawrapper.response.AvailableLanguages;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+public class AvailableLanguagesTest {
+    What3WordsV3 api = new What3WordsV3(System.getenv("W3W_API_KEY"));
+
+    @Test
+    public void validAvailableLanguagesTest() {
+        AvailableLanguages response = api.availableLanguages().execute();
+
+        assertTrue(response.isSuccessful());
+        assertTrue(response.getLanguages().size() > 0);
+    }
+}

--- a/src/test/java/com/what3words/javawrapper/ConvertToCoordinatesTest.java
+++ b/src/test/java/com/what3words/javawrapper/ConvertToCoordinatesTest.java
@@ -40,3 +40,4 @@ public class ConvertToCoordinatesTest {
         assertEquals("Bayswater, London", coords.getNearestPlace());
     }
 }
+

--- a/src/test/java/com/what3words/javawrapper/GridSectionGeoJsonTest.java
+++ b/src/test/java/com/what3words/javawrapper/GridSectionGeoJsonTest.java
@@ -1,0 +1,33 @@
+package com.what3words.javawrapper;
+
+import com.what3words.javawrapper.request.BoundingBox;
+import com.what3words.javawrapper.request.Coordinates;
+import com.what3words.javawrapper.response.APIResponse;
+import com.what3words.javawrapper.response.GridSection;
+import com.what3words.javawrapper.response.GridSectionGeoJson;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class GridSectionGeoJsonTest {
+    What3WordsV3 api = new What3WordsV3(System.getenv("W3W_API_KEY"));
+
+    @Test
+    public void invalidGridSectionTest() {
+        GridSectionGeoJson response = api.gridSectionGeoJson(new BoundingBox(new Coordinates(51.0, 0.0), new Coordinates(52.0, 0.1))).execute();
+
+        APIResponse.What3WordsError error = response.getError();
+
+        assertEquals(error, APIResponse.What3WordsError.BAD_BOUNDING_BOX_TOO_BIG);
+    }
+
+    @Test
+    public void validGridSectionTest() {
+        GridSectionGeoJson response = api.gridSectionGeoJson(new BoundingBox(new Coordinates(51.1122, 0.12221), new Coordinates(51.1333, 0.1223))).execute();
+
+        assertTrue(response.isSuccessful());
+        assertTrue(response.getFeatures().size() > 0);
+        assertNotNull(response.getType());
+    }
+}
+

--- a/src/test/java/com/what3words/javawrapper/GridSectionTest.java
+++ b/src/test/java/com/what3words/javawrapper/GridSectionTest.java
@@ -1,0 +1,32 @@
+package com.what3words.javawrapper;
+
+import com.what3words.javawrapper.request.BoundingBox;
+import com.what3words.javawrapper.request.Coordinates;
+import com.what3words.javawrapper.response.APIResponse;
+import com.what3words.javawrapper.response.GridSection;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class GridSectionTest {
+    What3WordsV3 api = new What3WordsV3(System.getenv("W3W_API_KEY"));
+
+    @Test
+    public void invalidGridSectionTest() {
+        GridSection response = api.gridSection(new BoundingBox(new Coordinates(51.0, 0.0), new Coordinates(52.0, 0.1))).execute();
+
+        APIResponse.What3WordsError error = response.getError();
+
+        assertEquals(error, APIResponse.What3WordsError.BAD_BOUNDING_BOX_TOO_BIG);
+    }
+
+    @Test
+    public void validGridSectionTest() {
+        GridSection response = api.gridSection(new BoundingBox(new Coordinates(51.1122,0.12221), new Coordinates(51.1333,0.1223))).execute();
+
+        assertTrue(response.isSuccessful());
+        assertTrue(response.getLines().size() > 0);
+    }
+}
+


### PR DESCRIPTION
- Added What3WordsJavaWrapper interface to What3WordsV3.
- Exposed options object on AutosuggestRequest and AutosuggestWithCoordinatesRequest to allow use it on SDK implementation
- Added public constructors to some of the DTOs to allow creating from SDK What3WordsJavaWrapper implementation
- Added testing to missing What3WordsJavaWrapper API implementation (availableLanguages, gridSection and gridSectionGeoJson)
- Added SDK_ERROR to What3WordsError Enum to allow to identify SDK errors only.