### PR TITLE
specified okhttp version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,6 +8,7 @@ plugins {
 ext {
     retrofit = "2.9.0"
     junit = "4.13.2"
+    okhttp = "4.10.0"
 }
 
 apply from: 'maven-push.gradle'
@@ -25,6 +26,7 @@ repositories {
 dependencies {
     implementation "com.squareup.retrofit2:retrofit:$retrofit"
     implementation "com.squareup.retrofit2:converter-gson:$retrofit"
+    implementation "com.squareup.okhttp3:okhttp:$okhttp"
     testImplementation "junit:junit:$junit"
 }
 


### PR DESCRIPTION
Specified OkHttp version to resolve the [CWE-295: Improper Certificate Validation](https://ossindex.sonatype.org/vulnerability/CVE-2021-0341?component-type=maven&component-name=com.squareup.okhttp3%2Fokhttp&utm_source=dependency-check&utm_medium=integration&utm_content=7.0.0) vulnerability 

Previously, there was an issue with [OkHttp3](https://square.github.io/okhttp), where its HttpUrl `get` method was missing after the migration of its HttpUrl class from Java to Kotlin. This resulted in a `java.lang.NoSuchMethodError`, when Retrofit was used with some recent versions of the OkHttp3 library. 

However, in the more recent OkHttp3 version `4.10.0`, this problem has been resolved. The get method with the signature `okhttp3.HttpUrl.get(Ljava/lang/String;)Lokhttp3/HttpUrl;` has been added back, even though it is currently marked as deprecated. Retrofit no longer encounters the `NoSuchMethodError` when the Retrofit.`Builder` class tries to invoke the OkHttp3 HttpUrl.`get` method.

This update in OkHttp3 version `4.10.0` resolves the issue, ensuring smooth operation with Retrofit.